### PR TITLE
Fix panics related to Walk func and also path handling in default layouts

### DIFF
--- a/trash.go
+++ b/trash.go
@@ -64,7 +64,7 @@ func main() {
 	exit(app.Run(os.Args))
 }
 
-var possibleTrashFiles = []string{"glide.yaml", "glide.yml", "trash.yaml"}
+var possibleTrashFiles = []string{"glide.yaml", "glide.yml", "trash.yaml", "trash.yml"}
 
 func run(c *cli.Context) error {
 	if c.Bool("debug") {
@@ -367,6 +367,10 @@ func chanPackagesFromLines(lnc <-chan string) <-chan util.Packages {
 func listPackages(rootPackage string) util.Packages {
 	r := util.Packages{}
 	filepath.Walk(rootPackage, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			logrus.Error(err)
+			return err
+		}
 		if !info.IsDir() {
 			return nil
 		}
@@ -501,12 +505,11 @@ func removeEmptyDirs(rootPackage string) error {
 }
 
 func cleanup(dir string, trashConf *conf.Trash) error {
-	gopath := path.Join(dir, "..", "..", "..", "..")
-	gopath = filepath.Clean(gopath)
+	gopath := filepath.Clean(dir)
 	os.Setenv("GOPATH", gopath)
 	logrus.Debugf("gopath: '%s'", gopath)
 
-	rootPackage := dir[len(gopath+"/src/"):]
+	rootPackage := dir + "/src/"
 	logrus.Debugf("rootPackage: '%s'", rootPackage)
 
 	os.Chdir(path.Join(gopath, "src"))


### PR DESCRIPTION
The stock code in 0.5.0 did not work in 2 cases and would panic.  

The first was within a filepath Walker function that upon encountering an error in the walk function would not test for the error and would then panic when trying to use input parameters to get file information.

The second is a bit mysterious.  When using cleanup the go path would use multiple up directory filepath components to navigate to the top of a directory tree.  If the GOPATH was set of a project in a local file system with for example /home/user/project would end up stripping important potions of the path.  This is probably because it is being run in another environment that does not use a directory tree for projects that are being used with trash.  I figure this is some incompatibility between the types of project structures that can be used with go.