### PR TITLE
fix: Repo gets deleted on update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin
 /dist
+.idea

--- a/trash.go
+++ b/trash.go
@@ -161,7 +161,8 @@ func updateTrash(trashDir, dir, trashFile string, trashConf *conf.Conf) error {
 		imports = collectImports(rootPackage, libRoot)
 	}
 
-	trashConf = &conf.Conf{Package: rootPackage}
+
+	newTrashConf := &conf.Conf{Package: rootPackage}
 	for pkg := range imports {
 		if pkg == rootPackage || strings.HasPrefix(pkg, rootPackage+"/") {
 			continue
@@ -179,12 +180,12 @@ func updateTrash(trashDir, dir, trashFile string, trashConf *conf.Conf) error {
 			return err
 		}
 		os.Chdir(dir)
-		trashConf.Imports = append(trashConf.Imports, i)
+		newTrashConf.Imports = append(newTrashConf.Imports, i)
 	}
-	trashConf.Dedupe()
+	newTrashConf.Dedupe()
 
 	os.Chdir(dir)
-	trashConf.Dump(trashFile)
+	newTrashConf.Dump(trashFile)
 
 	return nil
 }


### PR DESCRIPTION
Whenever you run `trash -u` a new vendor.conf is written minus any repo settings you may have had.

The bug was found where the variable that holds the conf was re-initialized, and then used to get existing configurations. 

This fix initializes a new variable and uses the old variable to get existing conf settings.