### PR TITLE
Detect and keep CGO dependencies from subfolders.

### DIFF
--- a/trash.go
+++ b/trash.go
@@ -519,9 +519,9 @@ func listImports(rootPackage, libRoot, pkg string) <-chan util.Packages {
 							// Extract any includes from the preamble
 							for _, line := range strings.Split(cg.Text(), "\n") {
 								if line = strings.TrimSpace(line); strings.HasPrefix(line, "#include \"") {
-									if path := filepath.Dir(line[10 : len(line)-1]); path != "." {
-										if _, err := os.Stat(filepath.Join(pkgPath, path)); !os.IsNotExist(err) {
-											sch <- filepath.Join(pkg, path)
+									if includePath := filepath.Dir(line[10 : len(line)-1]); includePath != "." {
+										if _, err := os.Stat(filepath.Join(pkgPath, includePath)); !os.IsNotExist(err) {
+											sch <- filepath.Clean(filepath.Join(pkg, includePath))
 										}
 									}
 								}

--- a/trash.go
+++ b/trash.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -459,6 +460,8 @@ func listImports(rootPackage, libRoot, pkg string) <-chan util.Packages {
 	}
 	go func() {
 		defer close(sch)
+
+		// Gather all the Go imports
 		ps, err := parser.ParseDir(token.NewFileSet(), pkgPath, noVendoredTests, parser.ImportsOnly)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -481,6 +484,50 @@ func listImports(rootPackage, libRoot, pkg string) <-chan util.Packages {
 					}
 					sch <- imp
 					logrus.Debugf("listImports, sch <- '%s'", v.Path.Value[1:len(v.Path.Value)-1])
+				}
+			}
+		}
+		// Gather all the CGO imports
+		ps, err = parser.ParseDir(token.NewFileSet(), pkgPath, noVendoredTests, parser.ParseComments)
+		if err != nil {
+			if os.IsNotExist(err) {
+				logrus.Debugf("listImports, pkgPath does not exist: %s", err)
+			} else {
+				logrus.Errorf("Error parsing comments, pkgPath: '%s', err: '%s'", pkgPath, err)
+			}
+			return
+		}
+		logrus.Infof("Collecting CGO imports for package '%s'", pkg)
+		for _, p := range ps {
+			for _, f := range p.Files {
+				// Drill down to locate C preable definitions
+				for _, decl := range f.Decls {
+					d, ok := decl.(*ast.GenDecl)
+					if !ok {
+						continue
+					}
+					for _, spec := range d.Specs {
+						s, ok := spec.(*ast.ImportSpec)
+						if !ok || s.Path.Value != `"C"` {
+							continue
+						}
+						cg := s.Doc
+						if cg == nil && len(d.Specs) == 1 {
+							cg = d.Doc
+						}
+						if cg != nil {
+							// Extract any includes from the preamble
+							for _, line := range strings.Split(cg.Text(), "\n") {
+								if line = strings.TrimSpace(line); strings.HasPrefix(line, "#include \"") {
+									if path := filepath.Dir(line[10 : len(line)-1]); path != "." {
+										if _, err := os.Stat(filepath.Join(pkgPath, path)); !os.IsNotExist(err) {
+											sch <- filepath.Join(pkg, path)
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR fixes an issue that's haunting all the dependency managers out there (e.g. https://github.com/tools/godep/issues/422), namely that they only take into consideration Go dependencies, and not CGO ones. This results in build failures for all projects where C files are in subfolders (i.e. most of them), as the dependency manager deletes all those folders thinking they are unused.

This fixes the issue by doing a second round of import scanning, where instead of looking for Go import statements, the code looks for CGO preambles and extracts any `#include "path"`-s where the path points to an existing folder. This will result in any folders references by CGO code to be kept, instead of trashed.