### PR TITLE
Resolve relative import paths.

### DIFF
--- a/trash.go
+++ b/trash.go
@@ -475,6 +475,8 @@ func listImports(rootPackage, libRoot, pkg string) <-chan util.Packages {
 					imp := v.Path.Value[1 : len(v.Path.Value)-1]
 					if pkgComponents := strings.Split(imp, "/"); !strings.Contains(pkgComponents[0], ".") {
 						continue
+					} else if pkgComponents[0] == "." || pkgComponents[0] == ".." {
+						imp = filepath.Clean(filepath.Join(pkg, imp))
 					}
 					if imp == rootPackage || strings.HasPrefix(imp, rootPackage+"/") {
 						continue


### PR DESCRIPTION
Although not recommended, some projects rarely do use relative import paths. One such example is a [build script in go-ethereum](https://github.com/ethereum/go-ethereum/blob/master/build/ci.go#L52) where we want to be able to run the script using `go run` without having `GOPATH` set up, but at the same time be able to use `internal` packages in the script.

Currently `trash` chokes on this as import paths starting with `.` or `..` pass the simple "externality" check of having a dot in the first path component. This PR adds a path expansion/cleanup so that if an imported package starts with `.` or `..`, the path is first resolved and only then added to the list of imports. This avoids operational failures when trying to check out packages of the form `../something`.