### PR TITLE
Support exclude patterns

### DIFF
--- a/trash.go
+++ b/trash.go
@@ -663,6 +663,39 @@ func removeUnusedImports(imports util.Packages) error {
 	})
 }
 
+func removeExcludes(excludes []string) error {
+	exclude := make(map[string]bool)
+	for _, dir := range excludes {
+		exclude[dir] = true
+	}
+	return filepath.Walk("vendor", func(path string, info os.FileInfo, err error) error {
+		logrus.Debugf("removeExcludes, path: '%s', err: '%v'", path, err)
+		if os.IsNotExist(err) {
+			return filepath.SkipDir
+		}
+		if err != nil {
+			return err
+		}
+		if path == "vendor" {
+			return nil
+		}
+		pkg := path[len("vendor/"):]
+		if exclude[pkg] {
+			logrus.Infof("Removing excluded dir: '%s'", path)
+			err := os.RemoveAll(path)
+			if err == nil {
+				return filepath.SkipDir
+			}
+			if os.IsNotExist(err) {
+				return filepath.SkipDir
+			}
+			logrus.Errorf("Error removing excluded dir, path: '%s', err: '%v'", path, err)
+			return err
+		}
+		return nil
+	})
+}
+
 func removeEmptyDirs() error {
 	for count := 1; count != 0; {
 		count = 0
@@ -724,6 +757,9 @@ func cleanup(dir string, trashConf *conf.Conf) error {
 	os.Chdir(dir)
 
 	imports := collectImports(rootPackage, "vendor")
+	if err := removeExcludes(trashConf.Excludes); err != nil {
+		logrus.Errorf("Error removing excluded dirs: %v", err)
+	}
 	if err := removeUnusedImports(imports); err != nil {
 		logrus.Errorf("Error removing unused dirs: %v", err)
 	}

--- a/trash.go
+++ b/trash.go
@@ -162,7 +162,8 @@ func updateTrash(trashDir, dir, trashFile string, trashConf *conf.Conf) error {
 		imports = collectImports(rootPackage, libRoot)
 	}
 
-	trashConf = &conf.Conf{Package: rootPackage}
+	trashConf.Package = rootPackage // Overwrite possibly non existent root package name
+	trashConf.Imports = nil         // Drop any old imports to include only new ones
 	for pkg := range imports {
 		if pkg == rootPackage || strings.HasPrefix(pkg, rootPackage+"/") {
 			continue
@@ -171,7 +172,7 @@ func updateTrash(trashDir, dir, trashFile string, trashConf *conf.Conf) error {
 		if err != nil {
 			return err
 		}
-		i, ok := trashConf.Get(pkg)
+		i, ok := trashConf.Get(pkg) // Get uses importMap for meta fields, which was preserved above
 		if !ok {
 			i = conf.Import{Package: pkg}
 		}


### PR DESCRIPTION
This PR contains an implementation of exclude patterns, where the user may specify certain packages )or folders) to exclude from vendoring. For the rationale behind this please see https://github.com/rancher/trash/issues/54.

The exclusion pattern in the plain config file format is an import path with an dash (`-`) preceding it, so it's unambiguous and backwards compatible with the current mode of operation. In yaml format a new `exclude` field is used which contains a list of paths to exclude. If an exclude pattern is present in the config file, `trash` will first delete those from any vendored packages and only then proceed with the `removeUnusedImports` step, ensuring that anything that only excluded packages depended on is also removed.
---

Beside the above feature, the PR contains two bugfixes:

Previously a `trash --update` overwrote any existing config file without retaining its original format (https://github.com/rancher/trash/issues/46). This had the unfortunate side effect that an original yaml config file was swapped out with a flat conf type. A proposal to fix this was done in https://github.com/rancher/trash/pull/50, but adding a new flag is a redundant operation since the code already knows what the original format was. This PR ensures that the original config file format (yaml or conf) is retained inside the `Conf` struct, allowing to serialize back to the same format on a dump.

Another bug was that `trash` recreated a new config structure from scratch on update, overwriting the old struct before the package metadata (version, external repo) could be extracted, losing all such information. A proposal was opened in https://github.com/rancher/trash/pull/51 to fix this, but it doesn't play nice with other internal/private fields in the `Conf` struct. This PR offers an alternative solution by not recreating the original config struct, just its `Imports` field. This was all private metadata is preserved, including the `importMap` containing the import meta fields.
