### PR TITLE
Retain original config file format

### DIFF
--- a/trash.go
+++ b/trash.go
@@ -162,7 +162,8 @@ func updateTrash(trashDir, dir, trashFile string, trashConf *conf.Conf) error {
 		imports = collectImports(rootPackage, libRoot)
 	}
 
-	trashConf = &conf.Conf{Package: rootPackage}
+	trashConf.Package = rootPackage // Overwrite possibly non existent root package name
+	trashConf.Imports = nil         // Drop any old imports to include only new ones
 	for pkg := range imports {
 		if pkg == rootPackage || strings.HasPrefix(pkg, rootPackage+"/") {
 			continue
@@ -171,7 +172,7 @@ func updateTrash(trashDir, dir, trashFile string, trashConf *conf.Conf) error {
 		if err != nil {
 			return err
 		}
-		i, ok := trashConf.Get(pkg)
+		i, ok := trashConf.Get(pkg) // Get uses importMap for meta fields, which was preserved above
 		if !ok {
 			i = conf.Import{Package: pkg}
 		}


### PR DESCRIPTION
Previously a `trash --update` overwrote any existing config file without retaining its original format (https://github.com/rancher/trash/issues/46). This had the unfortunate side effect that an original yaml config file was swapped out with a flat conf type. A proposal to fix this was done in https://github.com/rancher/trash/pull/50, but adding a new flag is a redundant operation since the code already knows what the original format was. This PR ensures that the original config file format (yaml or conf) is retained inside the `Conf` struct, allowing to serialize back to the same format on a dump.

Another bug was that `trash` recreated a new config structure from scratch on update, overwriting the old struct before the package metadata (version, external repo) could be extracted, losing all such information. A proposal was opened in https://github.com/rancher/trash/pull/51 to fix this, but it doesn't play nice with other internal/private fields in the `Conf` struct. This PR offers an alternative solution by not recreating the original config struct, just its `Imports` field. This was all private metadata is preserved, including the `importMap` containing the import meta fields.
