### PR TITLE
Do not attempt to preserve file permissions

### DIFF
--- a/trash.go
+++ b/trash.go
@@ -335,8 +335,10 @@ func cpy(vendorDir, trashDir string, i conf.Import) {
 	repoDir := path.Join(trashDir, "src", i.Package)
 	target, _ := path.Split(path.Join(vendorDir, i.Package))
 	os.MkdirAll(target, 0755)
-	if bytes, err := exec.Command("cp", "-a", repoDir, target).CombinedOutput(); err != nil {
-		logrus.Fatalf("`cp -a %s %s` failed:\n%s", repoDir, target, bytes)
+	// We use -dR instead of -a so that we don't inadvertently try to
+	// copy file permisisons on NFS.
+	if bytes, err := exec.Command("cp", "-dR", repoDir, target).CombinedOutput(); err != nil {
+		logrus.Fatalf("`cp -dR %s %s` failed:\n%s", repoDir, target, bytes)
 	}
 }
 


### PR DESCRIPTION
== Background

In common configurations of NFS, it is not possible to copy file
permissions. This manifests when using `cp -a`:

	$ cd /Volumes/Developer  # An NFS share.
	$ cp -a vendor.conf vendor.conf.bak
	cp: preserving permissions for 'vendor.conf.bak': Operation not permitted

== Overview

This diff changes the `cpy` method to use `cp -dR` instead of `cp -a`, which
is equivalent except for it doesn't copy permissions -- see MAN CP(1):

       -a, --archive
              same as -dR --preserve=all

== Testing

With the following vendor.conf file:

	temp

	github.com/go-ini/ini	v1.21.1-1-g2ba15ac

Previous behavior:

        temp$ $ trash -C .
	INFO[0000] Trash! Reading file: 'vendor.conf'
	INFO[0000] Using 'temp' as the project's root package (from vendor.conf)
	INFO[0000] Preparing cache for 'github.com/go-ini/ini'
	INFO[0001] Checking out 'github.com/go-ini/ini', commit: 'v1.21.1-1-g2ba15ac'
	INFO[0001] Copying deps...
	FATA[0001] `cp -a /home/vagrant/.trash-cache/src/github.com/go-ini/ini /Volumes/Developer/temp/vendor/github.com/go-ini/` failed:
	cp: preserving permissions for '/Volumes/Developer/temp/vendor/github.com/go-ini/ini/.git/refs/heads/master': Operation not permitted

New behavior:

	$ trash -C .
	INFO[0000] Trash! Reading file: 'vendor.conf'
	INFO[0000] Using 'temp' as the project's root package (from vendor.conf)
	INFO[0000] Checking out 'github.com/go-ini/ini', commit: 'v1.21.1-1-g2ba15ac'
	INFO[0000] Copying deps...
	INFO[0000] Copying deps... Done
	INFO[0000] removing '/Volumes/Developer/temp/vendor/github.com/go-ini/ini/.git
	INFO[0000] Collecting packages in 'temp'
	INFO[0000] Removing unused dir: 'vendor/github.com'
	WARN[0000] Package 'github.com/go-ini/ini' has been completely removed: it's probably useless (in vendor.conf)