### PR TITLE
fixes #67 Add support for build constraints

### DIFF
--- a/test/ignore.go
+++ b/test/ignore.go
@@ -1,0 +1,15 @@
+// +build ignore
+
+// package description
+package trashtestfixture
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func Foo() string {
+	logrus.Fatal("This is a test")
+	return fmt.Sprint("bar")
+}

--- a/trash.go
+++ b/trash.go
@@ -70,6 +70,11 @@ func main() {
 			Hidden: true,
 			EnvVar: "GOPATH",
 		},
+		cli.StringSliceFlag{
+			Name:  "skip-tag",
+			Usage: "Skip looking for imports in files with any of these build tags (flag can be used multiple times)",
+			// Consider the breaking change of defaulting to ["ignore"]
+		},
 	}
 	app.Action = run
 
@@ -91,6 +96,7 @@ func run(c *cli.Context) error {
 	insecure := c.Bool("insecure")
 	trashDir := c.String("cache")
 	gopath = c.String("gopath")
+	buildtagfilters := c.StringSlice("skip-tag")
 
 	trashDir, err := filepath.Abs(trashDir)
 	if err != nil {
@@ -129,7 +135,7 @@ func run(c *cli.Context) error {
 		return err
 	}
 	if update {
-		return updateTrash(trashDir, dir, targetDir, confFile, trashConf, insecure)
+		return updateTrash(trashDir, dir, targetDir, confFile, trashConf, insecure, buildtagfilters)
 	}
 	if err := vendor(keep, trashDir, dir, targetDir, trashConf, insecure); err != nil {
 		return err
@@ -137,10 +143,10 @@ func run(c *cli.Context) error {
 	if keep {
 		return nil
 	}
-	return cleanup(dir, targetDir, trashConf)
+	return cleanup(dir, targetDir, trashConf, buildtagfilters)
 }
 
-func updateTrash(trashDir, dir, targetDir, trashFile string, trashConf *conf.Conf, insecure bool) error {
+func updateTrash(trashDir, dir, targetDir, trashFile string, trashConf *conf.Conf, insecure bool, buildtagfilters []string) error {
 	// TODO collect imports, create `trashConf *conf.Trash`
 	rootPackage := trashConf.Package
 	if rootPackage == "" {
@@ -154,7 +160,7 @@ func updateTrash(trashDir, dir, targetDir, trashFile string, trashConf *conf.Con
 	importsLen := 0
 
 	os.Chdir(dir)
-	imports := collectImports(rootPackage, libRoot, targetDir)
+	imports := collectImports(rootPackage, libRoot, targetDir, buildtagfilters)
 	for len(imports) > importsLen {
 		importsLen = len(imports)
 		for pkg := range imports {
@@ -170,7 +176,7 @@ func updateTrash(trashDir, dir, targetDir, trashFile string, trashConf *conf.Con
 			checkout(trashDir, i)
 		}
 		os.Chdir(dir)
-		imports = collectImports(rootPackage, libRoot, targetDir)
+		imports = collectImports(rootPackage, libRoot, targetDir, buildtagfilters)
 	}
 
 	trashConf.Package = rootPackage // Overwrite possibly non existent root package name
@@ -458,7 +464,7 @@ func parentPackages(root, p string) util.Packages {
 	return r
 }
 
-func listImports(rootPackage, libRoot, pkg string) <-chan util.Packages {
+func listImports(rootPackage, libRoot, pkg string, buildtagfilters []string) <-chan util.Packages {
 	pkgPath := "."
 	if pkg != rootPackage {
 		if strings.HasPrefix(pkg, rootPackage+"/") {
@@ -479,7 +485,7 @@ func listImports(rootPackage, libRoot, pkg string) <-chan util.Packages {
 		defer close(sch)
 
 		// Gather all the Go imports
-		ps, err := parser.ParseDir(token.NewFileSet(), pkgPath, noVendoredTests, parser.ImportsOnly)
+		ps, err := parser.ParseDir(token.NewFileSet(), pkgPath, noVendoredTests, parser.ParseComments|parser.ImportsOnly)
 		if err != nil {
 			if os.IsNotExist(err) {
 				logrus.Debugf("listImports, pkgPath does not exist: %s", err)
@@ -491,6 +497,9 @@ func listImports(rootPackage, libRoot, pkg string) <-chan util.Packages {
 		logrus.Infof("Collecting imports for package '%s'", pkg)
 		for _, p := range ps {
 			for _, f := range p.Files {
+				if hasFilteredBuildTag(f, buildtagfilters) {
+					continue
+				}
 				for _, v := range f.Imports {
 					imp := v.Path.Value[1 : len(v.Path.Value)-1]
 					if pkgComponents := strings.Split(imp, "/"); !strings.Contains(pkgComponents[0], ".") {
@@ -555,6 +564,41 @@ func listImports(rootPackage, libRoot, pkg string) <-chan util.Packages {
 	return chanPackagesFromLines(lnc)
 }
 
+func hasFilteredBuildTag(f *ast.File, filtered []string) bool {
+	if len(f.Comments) == 0 {
+		// No build tags if no comments!
+		return false
+	}
+	block := f.Comments[0]
+	if block.Pos() > f.Package {
+		// Ignore import comments
+		return false
+	}
+	if block == f.Doc {
+		// Build tags cannot be in the package documentation
+		return false
+	}
+
+	// Loop through comment lines, searching for build tags
+	for _, line := range block.List {
+		comment := strings.TrimSpace(line.Text[2:])
+		if strings.HasPrefix(comment, "+build") {
+			tagline := strings.TrimSpace(strings.TrimPrefix(comment, "+build"))
+			groups := strings.Split(tagline, " ")
+			for _, grp := range groups {
+				for _, tag := range strings.Split(grp, ",") {
+					for _, filter := range filtered {
+						if tag == filter {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 func chanPackagesFromLines(lnc <-chan string) <-chan util.Packages {
 	return util.ChanPackages(func() util.Packages {
 		r := util.Packages{}
@@ -599,7 +643,7 @@ func listPackages(rootPackage, targetDir string) util.Packages {
 	return r
 }
 
-func collectImports(rootPackage, libRoot, targetDir string) util.Packages {
+func collectImports(rootPackage, libRoot, targetDir string, buildtagfilters []string) util.Packages {
 	logrus.Infof("Collecting packages in '%s'", rootPackage)
 
 	imports := util.Packages{}
@@ -609,7 +653,7 @@ func collectImports(rootPackage, libRoot, targetDir string) util.Packages {
 	for len(packages) > 0 {
 		cs := []<-chan util.Packages{}
 		for p := range packages {
-			cs = append(cs, listImports(rootPackage, libRoot, p))
+			cs = append(cs, listImports(rootPackage, libRoot, p, buildtagfilters))
 		}
 		for ps := range util.MergePackagesChans(cs...) {
 			imports.Merge(ps)
@@ -761,7 +805,7 @@ func guessRootPackage(dir string) string {
 	return dir[len(srcPath+"/"):]
 }
 
-func cleanup(dir, targetDir string, trashConf *conf.Conf) error {
+func cleanup(dir, targetDir string, trashConf *conf.Conf, buildtagfilters []string) error {
 	rootPackage := trashConf.Package
 	if rootPackage == "" {
 		rootPackage = guessRootPackage(dir)
@@ -771,7 +815,7 @@ func cleanup(dir, targetDir string, trashConf *conf.Conf) error {
 
 	os.Chdir(dir)
 
-	imports := collectImports(rootPackage, targetDir, targetDir)
+	imports := collectImports(rootPackage, targetDir, targetDir, buildtagfilters)
 	if err := removeExcludes(trashConf.Excludes, targetDir); err != nil {
 		logrus.Errorf("Error removing excluded dirs: %v", err)
 	}

--- a/trash_test.go
+++ b/trash_test.go
@@ -4,11 +4,35 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCollectImports(t *testing.T) {
+	defer logrus.SetLevel(logrus.GetLevel())
+	logrus.SetLevel(logrus.FatalLevel)
+
+	assert := require.New(t)
+	os.Chdir("./test")
+	defer os.Chdir("..")
+
+	libRoot := path.Join(os.Getenv("GOPATH"), "src")
+	trashCache := path.Join(os.Getenv("HOME"), ".trash-cache")
+
+	// Test that build tags are ignored
+	allPackages := collectImports(".", libRoot, trashCache, []string{})
+	assert.Equal(2, len(allPackages))
+	assert.Contains(allPackages, "github.com/Sirupsen/logrus")
+
+	// Test that a build tag can be used to filter
+	filteredPackages := collectImports(".", libRoot, trashCache, []string{"ignore"})
+	assert.Equal(1, len(filteredPackages))
+	assert.NotContains(filteredPackages, "github.com/Sirupsen/logrus")
+}
 
 func TestParentPackages(t *testing.T) {
 	assert := require.New(t)
@@ -48,8 +72,9 @@ func TestListPackages(t *testing.T) {
 	assert := require.New(t)
 	p := listPackages("github.com/rancher/trash", "vendor")
 	logrus.Debug(p)
-	assert.Equal(3, len(p))
+	assert.Equal(4, len(p))
 	assert.Contains(p, "github.com/rancher/trash")
 	assert.Contains(p, "github.com/rancher/trash/util")
 	assert.Contains(p, "github.com/rancher/trash/conf")
+	assert.Contains(p, "github.com/rancher/trash/test")
 }


### PR DESCRIPTION
During `--update`, imports from files with build tags specified with `--skip-tag` will not be vendored. This can save lots of space and network usage.

Added a test for `collectImports` that covers the old and new functionality.