### PR TITLE
Update program help in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ USAGE:
    trash [global options] command [command options] [arguments...]
 
 VERSION:
-   v0.2.5
+   v0.2.7
 
 AUTHOR(S):
    @imikushin, @ibuildthecloud
@@ -69,10 +69,13 @@ COMMANDS:
 GLOBAL OPTIONS:
    --file value, -f value       Vendored packages list (default: "vendor.conf")
    --directory value, -C value  The directory in which to run, --file is relative to this (default: ".")
+   --target value, -T value     The directory to store results (default: "vendor")
    --keep, -k                   Keep all downloaded vendor code (preserving .git dirs)
-   --update, -u                 Update vendored packages, add missing ones
+   --update value, -u value     specify a list of packages to be updated
+   --insecure                   Pass -insecure to 'go get'
    --debug, -d                  Debug logging
    --cache value                Cache directory (default: "/Users/ivan/.trash-cache") [$TRASH_CACHE]
+   --include-vendor             whether to include vendor when running trash -k
    --help, -h                   show help
    --version, -v                print the version
 ```


### PR DESCRIPTION
The `trash -h` output is not up to date with the latest version. I was forking this repository to add the `--target` option and it turned out it's already there, but missing from the readme.

I don't know whether you prefer the output of `v0.3.0-dev` or `v0.2.7`, but the only difference between those is line 61 (the version number).
